### PR TITLE
Refactor chat UI to use main column layout

### DIFF
--- a/local_chat.py
+++ b/local_chat.py
@@ -6,18 +6,21 @@ from tools import mcp_tools, run_tool
 st.set_page_config(page_title="Local AI ToolHub", layout="wide")
 st.title("📚 Local AI ToolHub – Query + Tools")
 
-# Sidebar settings
-with st.sidebar:
-    st.header("🤖 Model & Tools")
-    model = st.selectbox("Select Model", ["Qwen3 (General) ✨", "Holo1 (Book RAG) 📚"])
-    prompt = st.text_area("Your Prompt", height=200)
-    selected_tool = None
+# Model and tool selection in main layout
+st.header("🤖 Model & Tools")
+model_col, tool_col = st.columns(2)
 
+with model_col:
+    model = st.selectbox("Select Model", ["Qwen3 (General) ✨", "Holo1 (Book RAG) 📚"])
+
+with tool_col:
+    selected_tool = None
     if model.startswith("Qwen3"):
         st.markdown("### 🔧 MCP Tool (Optional)")
         selected_tool = st.selectbox("Choose a tool (or none)", ["None"] + list(mcp_tools.keys()))
 
-    submit = st.button("Run", type="primary")
+prompt = st.text_area("Your Prompt", height=200)
+submit = st.button("Run", type="primary")
 
 # Main output area
 if submit and prompt:


### PR DESCRIPTION
## Summary
- Remove sidebar configuration and move inputs to main layout
- Use columns for model and tool selection and keep prompt text area in main content

## Testing
- `python -m py_compile local_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_6894bd0230c0832982516d9ff64c83b9