### PR TITLE
Persist Chroma index for RAG

### DIFF
--- a/rag/holo_rag.py
+++ b/rag/holo_rag.py
@@ -1,15 +1,22 @@
 # Holo RAG Implementation
 # RAG (Retrieval-Augmented Generation) functionality
 # rag/holo_rag.py
-from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, Settings
+from llama_index.core import (
+    VectorStoreIndex,
+    SimpleDirectoryReader,
+    Settings,
+    StorageContext,
+    load_index_from_storage,
+)
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
 from llama_index.vector_stores.chroma import ChromaVectorStore
 from llama_index.core.node_parser import SentenceSplitter
 import chromadb
 import os
 
-BOOKS_DIR = r"C:\Users\jesse\Documents\Books\Books"
+BOOKS_DIR = os.getenv("BOOKS_DIR", r"C:\Users\jesse\Documents\Books\Books")
 CHROMA_DIR = "rag/chroma_store"
+PERSIST_DIR = "rag/storage"
 
 # Setup once
 embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-small-en-v1.5")
@@ -21,12 +28,21 @@ chroma_client = chromadb.PersistentClient(path=CHROMA_DIR)
 chroma_collection = chroma_client.get_or_create_collection("books")
 vector_store = ChromaVectorStore(chroma_collection=chroma_collection)
 
-# Load documents and create index
-documents = SimpleDirectoryReader(BOOKS_DIR).load_data()
-parser = SentenceSplitter()
-nodes = parser.get_nodes_from_documents(documents)
-
-index = VectorStoreIndex(nodes, storage_context=None)
+# Load or build index
+if os.path.exists(PERSIST_DIR) and os.listdir(PERSIST_DIR):
+    storage_context = StorageContext.from_defaults(
+        persist_dir=PERSIST_DIR, vector_store=vector_store
+    )
+    index = load_index_from_storage(storage_context)
+else:
+    documents = SimpleDirectoryReader(BOOKS_DIR).load_data()
+    parser = SentenceSplitter()
+    nodes = parser.get_nodes_from_documents(documents)
+    storage_context = StorageContext.from_defaults(
+        persist_dir=PERSIST_DIR, vector_store=vector_store
+    )
+    index = VectorStoreIndex(nodes, storage_context=storage_context)
+    index.storage_context.persist()
 query_engine = index.as_query_engine(similarity_top_k=5)
 
 # Callable function for Streamlit


### PR DESCRIPTION
## Summary
- create storage context with Chroma vector store and reuse existing index
- load from persistent storage or build and persist new Chroma index
- allow `BOOKS_DIR` override via environment variable

## Testing
- `python -m py_compile rag/holo_rag.py`

------
https://chatgpt.com/codex/tasks/task_e_6894bd002fd48329a516c61b3c9c06e1